### PR TITLE
MGDAPI-4639 Support for OpenShift 4.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ differences:
 * Updated *.gitignore* with `openapi.json` and `openapi.yaml`
 * Added the `quarkus-openshift` extension
 
+## Building Docker Image
+(Re)Create the JAR file for the project to convert it into a distributable format
+```bash
+mvn package
+
+```
+Build the image (make sure to change quay.io ORG as needed)
+```bash
+docker build -f src/main/docker/Dockerfile.jvm -t quay.io/{ORG}/rhoam-quarkus-openapi:latest .
+```
+The image can be pushed to quay.io or run locally if needed using `docker run`
+```bash
+docker run -i --rm -p 8080:8080 quay.io/{ORG}/rhoam-quarkus-openapi:latest
+```
+
 ## Usage
 
 Verify that your system meets the following requirements:

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -32,7 +32,7 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
     && chown 1001:root /deployments \
     && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
     && chown 1001 /deployments/run-java.sh \
-    && chmod 540 /deployments/run-java.sh \
+    && chmod 550 /deployments/run-java.sh \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-4639

# What
This PR updates the README with instructions for building and running the docker image. It also updates the Dockerfile to allow group execute permissions for the `run-java.sh` script. This is required to allow the image to run on OpenShift 4.11.

# Verification Steps
None - this change will be verified as part of this [PR](https://github.com/integr8ly/integreatly-operator/pull/2972) to integreatly-operator.
